### PR TITLE
Make GLFWInput and GLFWInputT into newtypes.

### DIFF
--- a/examples/Cursor.hs
+++ b/examples/Cursor.hs
@@ -200,7 +200,7 @@ run win ictl = do
       -- state (for example if the wire debounced any keys). This is what we pass
       -- back to GLFW.
       --  renderPrg :: IO ((Either e (), Wire s e GameMonad a ()), GLFWInputState)
-      let renderPrg = runStateT (stepWire w timeState (Right undefined)) ipt'
+      let renderPrg = runGLFWInputT (stepWire w timeState (Right undefined)) ipt'
 
       -- Now run the actual IO program to extract the values from it.
       ((result, w'), ipt'') <- renderPrg

--- a/lib/FRP/Netwire/Input/GLFW.hs
+++ b/lib/FRP/Netwire/Input/GLFW.hs
@@ -110,26 +110,24 @@ type GLFWInput = GLFWInputT Identity
 runGLFWInput :: GLFWInput a -> GLFWInputState -> (a, GLFWInputState)
 runGLFWInput m is = runIdentity (runGLFWInputT m is)
 
-instance (Functor m, Monad m) =>
-         MonadKeyboard GLFW.Key (GLFWInputT m) where
+instance Monad m => MonadKeyboard GLFW.Key (GLFWInputT m) where
 
   keyIsPressed :: GLFW.Key -> GLFWInputT m Bool
-  keyIsPressed key = GLFWInputT (isKeyDown key <$> get)
+  keyIsPressed key = GLFWInputT . liftM (isKeyDown key) $ get
 
   releaseKey :: GLFW.Key -> GLFWInputT m ()
   releaseKey key = GLFWInputT (get >>= (put . debounceKey key))
 
-instance (Functor m, Monad m) =>
-         MonadMouse GLFW.MouseButton (GLFWInputT m) where
+instance Monad m => MonadMouse GLFW.MouseButton (GLFWInputT m) where
 
   mbIsPressed :: GLFW.MouseButton -> GLFWInputT m Bool
-  mbIsPressed mb = GLFWInputT (isButtonPressed mb <$> get)
+  mbIsPressed mb = GLFWInputT . liftM (isButtonPressed mb) $ get
 
   releaseButton :: GLFW.MouseButton -> GLFWInputT m ()
   releaseButton mb = GLFWInputT (get >>= (put . debounceButton mb))
 
   cursor :: GLFWInputT m (Float, Float)
-  cursor = GLFWInputT (cursorPos <$> get)
+  cursor = GLFWInputT . liftM cursorPos $ get
 
   setCursorMode :: CursorMode -> GLFWInputT m ()
   setCursorMode mode = do
@@ -137,7 +135,7 @@ instance (Functor m, Monad m) =>
     GLFWInputT $ put (ipt { cmode = mode })
 
   scroll :: GLFWInputT m (Double, Double)
-  scroll = GLFWInputT (scrollAmt <$> get)
+  scroll = GLFWInputT . liftM scrollAmt $ get
 
 kEmptyInput :: GLFWInputState
 kEmptyInput = GLFWInputState { keysPressed = Map.empty,

--- a/netwire-input-glfw.cabal
+++ b/netwire-input-glfw.cabal
@@ -12,9 +12,9 @@ description:         This package contains the necessary glue to allow the use
 homepage:            https://www.github.com/Mokosha/netwire-input-glfw
 license:             MIT
 license-file:        LICENSE
-author:              Pavel Krajcevski, Bradley Hardy
-maintainer:          bradleyhardy@live.com
-copyright:           Pavel Krajcevski, 2014; Bradley Hardy, 2015
+author:              Pavel Krajcevski
+maintainer:          krajcevski@gmail.com
+copyright:           Pavel Krajcevski, 2014
 category:            Game
 build-type:          Simple
 extra-source-files:  examples/Cursor.hs README.md

--- a/netwire-input-glfw.cabal
+++ b/netwire-input-glfw.cabal
@@ -2,7 +2,7 @@
 -- documentation, see http://haskell.org/cabal/users-guide/
 
 name:                netwire-input-glfw
-version:             0.0.3
+version:             0.0.4
 synopsis:            GLFW instance of netwire-input
 description:         This package contains the necessary glue to allow the use
                      of wires from the netwire-input package. In general, the types
@@ -12,9 +12,9 @@ description:         This package contains the necessary glue to allow the use
 homepage:            https://www.github.com/Mokosha/netwire-input-glfw
 license:             MIT
 license-file:        LICENSE
-author:              Pavel Krajcevski
-maintainer:          Krajcevski@gmail.com
-copyright:           Pavel Krajcevski, 2014
+author:              Pavel Krajcevski, Bradley Hardy
+maintainer:          bradleyhardy@live.com
+copyright:           Pavel Krajcevski, 2014; Bradley Hardy, 2015
 category:            Game
 build-type:          Simple
 extra-source-files:  examples/Cursor.hs README.md
@@ -35,12 +35,13 @@ library
                        InstanceSigs
   exposed-modules:     FRP.Netwire.Input.GLFW
   -- other-modules:       
-  build-depends:       base >=4.6 && <4.8,
-                       netwire-input,
+  build-depends:       base >=4.6 && <4.9,
+                       netwire-input ==0.0.4,
                        containers,
-                       GLFW-b >= 1.4.7.2,
+                       GLFW-b,
                        stm,
-                       mtl
+                       mtl,
+                       MonadRandom
   hs-source-dirs:      lib
   default-language:    Haskell2010
 
@@ -58,10 +59,10 @@ executable glfw-input-example
   if flag(examples)
     build-depends:  base > 4.5,
                     netwire >= 5,
-                    netwire-input,
+                    netwire-input ==0.0.4,
                     netwire-input-glfw,
                     OpenGL,
-                    GLFW-b >= 1.4.7.2,
+                    GLFW-b,
                     transformers,
                     array,
                     bytestring,

--- a/netwire-input-glfw.cabal
+++ b/netwire-input-glfw.cabal
@@ -22,7 +22,7 @@ cabal-version:       >=1.10
 
 flag                 examples
   description:       Build examples
-  default:           False
+  default:           True
 
 source-repository head
   type:           git
@@ -36,7 +36,7 @@ library
   exposed-modules:     FRP.Netwire.Input.GLFW
   -- other-modules:       
   build-depends:       base >=4.6 && <4.9,
-                       netwire-input ==0.0.4,
+                       netwire-input,
                        containers,
                        GLFW-b,
                        stm,
@@ -59,8 +59,8 @@ executable glfw-input-example
   if flag(examples)
     build-depends:  base > 4.5,
                     netwire >= 5,
-                    netwire-input ==0.0.4,
-                    netwire-input-glfw,
+                    netwire-input,
+                    netwire-input-glfw ==0.0.4,
                     OpenGL,
                     GLFW-b,
                     transformers,

--- a/netwire-input-glfw.cabal
+++ b/netwire-input-glfw.cabal
@@ -22,7 +22,7 @@ cabal-version:       >=1.10
 
 flag                 examples
   description:       Build examples
-  default:           True
+  default:           False
 
 source-repository head
   type:           git
@@ -40,8 +40,7 @@ library
                        containers,
                        GLFW-b,
                        stm,
-                       mtl,
-                       MonadRandom
+                       mtl
   hs-source-dirs:      lib
   default-language:    Haskell2010
 

--- a/netwire-input-glfw.cabal
+++ b/netwire-input-glfw.cabal
@@ -2,7 +2,7 @@
 -- documentation, see http://haskell.org/cabal/users-guide/
 
 name:                netwire-input-glfw
-version:             0.0.4
+version:             0.0.5
 synopsis:            GLFW instance of netwire-input
 description:         This package contains the necessary glue to allow the use
                      of wires from the netwire-input package. In general, the types


### PR DESCRIPTION
This change makes it a lot easier to use a GLFWInputT as part of a transformer stack that includes another StateT. I've also added a lot of derived instances (using GeneralizedNewtypeDeriving) so it's convenient to use at the top of the stack.
