### PR TITLE
Update dependency constraints

### DIFF
--- a/netwire-input-glfw.cabal
+++ b/netwire-input-glfw.cabal
@@ -38,9 +38,9 @@ library
   build-depends:       base >=4.6 && <4.9,
                        netwire-input,
                        containers,
-                       GLFW-b,
+                       GLFW-b < 1.4.8,
                        stm,
-                       mtl
+                       mtl >= 2.2.1
   hs-source-dirs:      lib
   default-language:    Haskell2010
 
@@ -59,15 +59,16 @@ executable glfw-input-example
     build-depends:  base > 4.5,
                     netwire >= 5,
                     netwire-input,
-                    netwire-input-glfw ==0.0.4,
+                    netwire-input-glfw ==0.0.5,
                     OpenGL,
-                    GLFW-b,
+                    GLFW-b < 1.4.8,
                     transformers,
                     array,
                     bytestring,
-                    mtl,
+                    mtl >= 2.2.1,
                     containers,
                     directory,
                     filepath
+    default-language:  Haskell2010
   else
     buildable:      False


### PR DESCRIPTION
mtl >= 2.2.1, GLFW-b < 1.4.8.

After this, example compiled with these warnings:

```
examples/Cursor.hs:5:1: Warning:
    The import of ‘Control.Monad.Trans.Class’ is redundant
      except perhaps to import instances from ‘Control.Monad.Trans.Class’
    To import instances alone, use: import Control.Monad.Trans.Class()

examples/Cursor.hs:179:37: Warning:
    Defaulting the following constraint(s) to type ‘Double’
      (Real t0)
        arising from a use of ‘gameWire’ at examples/Cursor.hs:179:37-44
      (Num t0)
        arising from a use of ‘gameWire’ at examples/Cursor.hs:179:37-44
      (Fractional t0)
        arising from the literal ‘0.02’ at examples/Cursor.hs:179:30-33
    In the expression: gameWire
    In the third argument of ‘runGame’, namely
      ‘(gameWire $ renderFn circle)’
    In a stmt of a 'do' block:
      runGame ipt (countSession_ 0.02) (gameWire $ renderFn circle)

examples/Cursor.hs:223:3: Warning:
    A do-notation statement discarded a result of type ‘Bool’
    Suppress this warning by saying ‘_ <- GLFW.init’
    or by using the flag -fno-warn-unused-do-bind
```
